### PR TITLE
Add context support to Todoist endpoints

### DIFF
--- a/pkg/todoist/client.go
+++ b/pkg/todoist/client.go
@@ -2,6 +2,7 @@ package todoist
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -32,7 +33,12 @@ func NewClient(apiKey string) *Client {
 	}
 }
 
-func (c *Client) request(method, endpoint string, body any, query any) (*http.Response, error) {
+func (c *Client) request(
+	ctx context.Context,
+	method, endpoint string,
+	body any,
+	query any,
+) (*http.Response, error) {
 	requestURL, err := url.Parse(c.BaseURL + endpoint)
 	if err != nil {
 		return nil, err
@@ -56,7 +62,7 @@ func (c *Client) request(method, endpoint string, body any, query any) (*http.Re
 		reqBody = bytes.NewReader(nil)
 	}
 
-	req, err := http.NewRequest(method, requestURL.String(), reqBody)
+	req, err := http.NewRequestWithContext(ctx, method, requestURL.String(), reqBody)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/todoist/labels.go
+++ b/pkg/todoist/labels.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -41,8 +42,11 @@ type LabelOptions struct {
 // By default, the names of a user's personal labels will also be included.
 // These can be excluded by passing the OmitPersonal field in the
 // SharedLabelFilters.
-func (c *Client) SharedLabels(filters *SharedLabelFilters) ([]string, *string, error) {
-	res, err := c.request("GET", "/labels/shared", filters, nil)
+func (c *Client) SharedLabels(
+	ctx context.Context,
+	filters *SharedLabelFilters,
+) ([]string, *string, error) {
+	res, err := c.request(ctx, "GET", "/labels/shared", filters, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get shared labels: %w", err)
 	}
@@ -62,8 +66,11 @@ func (c *Client) SharedLabels(filters *SharedLabelFilters) ([]string, *string, e
 }
 
 // GetLabels returns a list of all user labels.
-func (c *Client) GetLabels(filters *PaginationFilters) ([]Label, *string, error) {
-	res, err := c.request("GET", "/labels", nil, filters)
+func (c *Client) GetLabels(
+	ctx context.Context,
+	filters *PaginationFilters,
+) ([]Label, *string, error) {
+	res, err := c.request(ctx, "GET", "/labels", nil, filters)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get labels: %w", err)
 	}
@@ -84,7 +91,11 @@ func (c *Client) GetLabels(filters *PaginationFilters) ([]Label, *string, error)
 
 // CreateLabel creates a new personal label with the given name.
 // The name is required and will override the value in the LabelOptions.
-func (c *Client) CreateLabel(name string, options *LabelOptions) (*Label, error) {
+func (c *Client) CreateLabel(
+	ctx context.Context,
+	name string,
+	options *LabelOptions,
+) (*Label, error) {
 	if name == "" {
 		return nil, fmt.Errorf("label name is required")
 	}
@@ -95,7 +106,7 @@ func (c *Client) CreateLabel(name string, options *LabelOptions) (*Label, error)
 
 	options.Name = name
 
-	res, err := c.request("POST", "/labels", options, nil)
+	res, err := c.request(ctx, "POST", "/labels", options, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create label: %w", err)
 	}
@@ -117,12 +128,12 @@ func (c *Client) CreateLabel(name string, options *LabelOptions) (*Label, error)
 // SharedLabelsRemove removes the given shared label from all active tasks. If
 // no instances of the label name are found, the request will still be
 // considered successful.
-func (c *Client) SharedLabelsRemove(name string) error {
+func (c *Client) SharedLabelsRemove(ctx context.Context, name string) error {
 	if name == "" {
 		return fmt.Errorf("label name is required")
 	}
 
-	res, err := c.request("POST", "/labels/shared/remove", LabelOptions{Name: name}, nil)
+	res, err := c.request(ctx, "POST", "/labels/shared/remove", LabelOptions{Name: name}, nil)
 	if err != nil {
 		return fmt.Errorf("failed to remove shared label: %w", err)
 	}
@@ -136,7 +147,7 @@ func (c *Client) SharedLabelsRemove(name string) error {
 }
 
 // SharedLabelsRename renames the given shared label from all active tasks.
-func (c *Client) SharedLabelsRename(name string, newName string) error {
+func (c *Client) SharedLabelsRename(ctx context.Context, name string, newName string) error {
 	if name == "" {
 		return fmt.Errorf("label name is required")
 	}
@@ -145,6 +156,7 @@ func (c *Client) SharedLabelsRename(name string, newName string) error {
 	}
 
 	res, err := c.request(
+		ctx,
 		"POST",
 		"/labels/shared/rename",
 		SharedLabelOptions{NewName: newName},
@@ -164,12 +176,12 @@ func (c *Client) SharedLabelsRename(name string, newName string) error {
 
 // DeleteLabel deletes a personal label by its ID. All instances of the label
 // will be removed from tasks.
-func (c *Client) DeleteLabel(id string) error {
+func (c *Client) DeleteLabel(ctx context.Context, id string) error {
 	if id == "" {
 		return fmt.Errorf("label ID is required")
 	}
 
-	res, err := c.request("DELETE", fmt.Sprintf("/labels/%s", id), nil, nil)
+	res, err := c.request(ctx, "DELETE", fmt.Sprintf("/labels/%s", id), nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete label: %w", err)
 	}
@@ -183,12 +195,12 @@ func (c *Client) DeleteLabel(id string) error {
 }
 
 // GetLabel returns a label by its ID.
-func (c *Client) GetLabel(id string) (*Label, error) {
+func (c *Client) GetLabel(ctx context.Context, id string) (*Label, error) {
 	if id == "" {
 		return nil, fmt.Errorf("label ID is required")
 	}
 
-	res, err := c.request("GET", fmt.Sprintf("/labels/%s", id), nil, nil)
+	res, err := c.request(ctx, "GET", fmt.Sprintf("/labels/%s", id), nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get label: %w", err)
 	}
@@ -209,7 +221,11 @@ func (c *Client) GetLabel(id string) (*Label, error) {
 
 // UpdateLabel updates a label by its ID. The ID is required, and the
 // LabelOptions are required to specify the fields to update.
-func (c *Client) UpdateLabel(id string, options *LabelOptions) (*Label, error) {
+func (c *Client) UpdateLabel(
+	ctx context.Context,
+	id string,
+	options *LabelOptions,
+) (*Label, error) {
 	if id == "" {
 		return nil, fmt.Errorf("label ID is required")
 	}
@@ -217,7 +233,7 @@ func (c *Client) UpdateLabel(id string, options *LabelOptions) (*Label, error) {
 		return nil, fmt.Errorf("options are required")
 	}
 
-	res, err := c.request("POST", fmt.Sprintf("/labels/%s", id), options, nil)
+	res, err := c.request(ctx, "POST", fmt.Sprintf("/labels/%s", id), options, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update label: %w", err)
 	}

--- a/pkg/todoist/projects.go
+++ b/pkg/todoist/projects.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -65,8 +66,11 @@ type Collaborator struct {
 
 // GetProjects returns a list containing all active user projects and a cursor
 // for pagination. The cursor is nil if there are no more pages to return.
-func (c *Client) GetProjects(pagination *PaginationFilters) ([]Project, *string, error) {
-	res, err := c.request("GET", "/projects/", nil, pagination)
+func (c *Client) GetProjects(
+	ctx context.Context,
+	pagination *PaginationFilters,
+) ([]Project, *string, error) {
+	res, err := c.request(ctx, "GET", "/projects/", nil, pagination)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -86,8 +90,11 @@ func (c *Client) GetProjects(pagination *PaginationFilters) ([]Project, *string,
 
 // GetArchived returns a list containing all archived user projects and a cursor
 // for pagination. The cursor is nil if there are no more pages to return.
-func (c *Client) GetArchived(pagination *PaginationFilters) ([]Project, *string, error) {
-	res, err := c.request("GET", "/projects/archived", nil, pagination)
+func (c *Client) GetArchived(
+	ctx context.Context,
+	pagination *PaginationFilters,
+) ([]Project, *string, error) {
+	res, err := c.request(ctx, "GET", "/projects/archived", nil, pagination)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -108,11 +115,15 @@ func (c *Client) GetArchived(pagination *PaginationFilters) ([]Project, *string,
 // CreateProject creates a new project with the given name and options.
 // The name is required, and any additional options can be set in the
 // ProjectOptions
-func (c *Client) CreateProject(name string, options *ProjectOptions) (*Project, error) {
+func (c *Client) CreateProject(
+	ctx context.Context,
+	name string,
+	options *ProjectOptions,
+) (*Project, error) {
 	body := options
 	body.Name = name
 
-	res, err := c.request("POST", "/projects", body, nil)
+	res, err := c.request(ctx, "POST", "/projects", body, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -131,8 +142,8 @@ func (c *Client) CreateProject(name string, options *ProjectOptions) (*Project, 
 }
 
 // GetProject returns a project related to the given projectId.
-func (c *Client) GetProject(projectId string) (*Project, error) {
-	res, err := c.request("GET", fmt.Sprintf("/projects/%s", projectId), nil, nil)
+func (c *Client) GetProject(ctx context.Context, projectId string) (*Project, error) {
+	res, err := c.request(ctx, "GET", fmt.Sprintf("/projects/%s", projectId), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -152,8 +163,12 @@ func (c *Client) GetProject(projectId string) (*Project, error) {
 
 // UpdateProject updates a project with the given projectId with the given
 // ProjectOptions.
-func (c *Client) UpdateProject(projectId string, options *ProjectOptions) (*Project, error) {
-	res, err := c.request("POST", fmt.Sprintf("/projects/%s", projectId), options, nil)
+func (c *Client) UpdateProject(
+	ctx context.Context,
+	projectId string,
+	options *ProjectOptions,
+) (*Project, error) {
+	res, err := c.request(ctx, "POST", fmt.Sprintf("/projects/%s", projectId), options, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -172,8 +187,8 @@ func (c *Client) UpdateProject(projectId string, options *ProjectOptions) (*Proj
 }
 
 // ArchiveProject archives a project with the given projectId.
-func (c *Client) ArchiveProject(projectId string) error {
-	res, err := c.request("POST", fmt.Sprintf("/projects/%s/archive", projectId), nil, nil)
+func (c *Client) ArchiveProject(ctx context.Context, projectId string) error {
+	res, err := c.request(ctx, "POST", fmt.Sprintf("/projects/%s/archive", projectId), nil, nil)
 	if err != nil {
 		return err
 	}
@@ -187,8 +202,8 @@ func (c *Client) ArchiveProject(projectId string) error {
 }
 
 // UnarchiveProject unarchives a project with the given projectId.
-func (c *Client) UnarchiveProject(projectId string) error {
-	res, err := c.request("POST", fmt.Sprintf("/projects/%s/unarchive", projectId), nil, nil)
+func (c *Client) UnarchiveProject(ctx context.Context, projectId string) error {
+	res, err := c.request(ctx, "POST", fmt.Sprintf("/projects/%s/unarchive", projectId), nil, nil)
 	if err != nil {
 		return err
 	}
@@ -202,8 +217,8 @@ func (c *Client) UnarchiveProject(projectId string) error {
 }
 
 // DeleteProject deletes a project with the given projectId.
-func (c *Client) DeleteProject(projectId string) error {
-	res, err := c.request("DELETE", fmt.Sprintf("/projects/%s", projectId), nil, nil)
+func (c *Client) DeleteProject(ctx context.Context, projectId string) error {
+	res, err := c.request(ctx, "DELETE", fmt.Sprintf("/projects/%s", projectId), nil, nil)
 	if err != nil {
 		return err
 	}
@@ -219,10 +234,12 @@ func (c *Client) DeleteProject(projectId string) error {
 // projectId and a cursor for pagination. The cursor is nil if there are no
 // more pages to return.
 func (c *Client) GetProjectCollaborators(
+	ctx context.Context,
 	projectId string,
 	pagination *PaginationFilters,
 ) ([]Collaborator, *string, error) {
 	res, err := c.request(
+		ctx,
 		"GET",
 		fmt.Sprintf("/projects/%s/collaborators", projectId),
 		nil,

--- a/pkg/todoist/sections.go
+++ b/pkg/todoist/sections.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -38,6 +39,7 @@ type SectionOptions struct {
 // CreateSection creates a new section in the specified project. The parameters
 // name and projectID are required. They will override the values in options.
 func (c *Client) CreateSection(
+	ctx context.Context,
 	name string,
 	projectID string,
 	options *SectionOptions,
@@ -56,7 +58,7 @@ func (c *Client) CreateSection(
 	options.Name = name
 	options.ProjectID = projectID
 
-	res, err := c.request("POST", "/sections", options, nil)
+	res, err := c.request(ctx, "POST", "/sections", options, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create section: %w", err)
 	}
@@ -77,8 +79,11 @@ func (c *Client) CreateSection(
 
 // GetSections returns a list of all active sections for the user
 // or a specific project if filters.ProjectID is provided.
-func (c *Client) GetSections(filters *SectionFilters) ([]Section, *string, error) {
-	res, err := c.request("GET", "/sections", nil, filters)
+func (c *Client) GetSections(
+	ctx context.Context,
+	filters *SectionFilters,
+) ([]Section, *string, error) {
+	res, err := c.request(ctx, "GET", "/sections", nil, filters)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get sections: %w", err)
 	}
@@ -98,12 +103,12 @@ func (c *Client) GetSections(filters *SectionFilters) ([]Section, *string, error
 }
 
 // GetSection returns the section for the given section ID
-func (c *Client) GetSection(id string) (*Section, error) {
+func (c *Client) GetSection(ctx context.Context, id string) (*Section, error) {
 	if id == "" {
 		return nil, fmt.Errorf("section ID is required")
 	}
 
-	res, err := c.request("GET", fmt.Sprintf("/sections/%s", id), nil, nil)
+	res, err := c.request(ctx, "GET", fmt.Sprintf("/sections/%s", id), nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get section: %w", err)
 	}
@@ -123,7 +128,7 @@ func (c *Client) GetSection(id string) (*Section, error) {
 }
 
 // UpdateSection updates the section name with the given ID.
-func (c *Client) UpdateSection(id string, name string) (*Section, error) {
+func (c *Client) UpdateSection(ctx context.Context, id string, name string) (*Section, error) {
 	if id == "" {
 		return nil, fmt.Errorf("section ID is required")
 	}
@@ -135,7 +140,7 @@ func (c *Client) UpdateSection(id string, name string) (*Section, error) {
 		Name: name,
 	}
 
-	res, err := c.request("POST", fmt.Sprintf("/sections/%s", id), options, nil)
+	res, err := c.request(ctx, "POST", fmt.Sprintf("/sections/%s", id), options, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update section: %w", err)
 	}
@@ -155,12 +160,12 @@ func (c *Client) UpdateSection(id string, name string) (*Section, error) {
 }
 
 // DeleteSection deletes the section with the given ID and all of its tasks.
-func (c *Client) DeleteSection(id string) error {
+func (c *Client) DeleteSection(ctx context.Context, id string) error {
 	if id == "" {
 		return fmt.Errorf("section ID is required")
 	}
 
-	res, err := c.request("DELETE", fmt.Sprintf("/sections/%s", id), nil, nil)
+	res, err := c.request(ctx, "DELETE", fmt.Sprintf("/sections/%s", id), nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete section: %w", err)
 	}

--- a/pkg/todoist/tasks.go
+++ b/pkg/todoist/tasks.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -50,7 +51,7 @@ type TaskOptions struct {
 	DueDate      string   `json:"due_date,omitempty"`
 	DueDateTime  string   `json:"due_datetime,omitempty"`
 	DueLang      string   `json:"due_lang,omitempty"`
-	Duration     int      `json:"duration,omitempty"` // If duration is set, duration_unit must also be set
+	Duration     int      `json:"duration,omitempty"`      // If duration is set, duration_unit must also be set
 	DurationUnit string   `json:"duration_unit,omitempty"` // The unit of the duration has to be "day" or "minute".
 	DeadlineDate string   `json:"deadline_date,omitempty"`
 	DeadlineLang string   `json:"deadline_lang,omitempty"`
@@ -68,14 +69,18 @@ type TaskFilters struct {
 	PaginationFilters
 }
 
-func (c *Client) CreateTask(content string, options *TaskOptions) (*Task, error) {
+func (c *Client) CreateTask(
+	ctx context.Context,
+	content string,
+	options *TaskOptions,
+) (*Task, error) {
 	body := options
 	if body == nil {
 		body = &TaskOptions{}
 	}
 	body.Content = content
 
-	res, err := c.request("POST", "/tasks", body, nil)
+	res, err := c.request(ctx, "POST", "/tasks", body, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +100,8 @@ func (c *Client) CreateTask(content string, options *TaskOptions) (*Task, error)
 
 // GetTasks returns a list containing all active user tasks and a cursor for
 // pagination. The cursor is nil if there are no more pages to return.
-func (c *Client) GetTasks(filters *TaskFilters) ([]Task, *string, error) {
-	res, err := c.request("GET", "/tasks", nil, filters)
+func (c *Client) GetTasks(ctx context.Context, filters *TaskFilters) ([]Task, *string, error) {
+	res, err := c.request(ctx, "GET", "/tasks", nil, filters)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -124,13 +129,17 @@ func (c *Client) GetTasks(filters *TaskFilters) ([]Task, *string, error) {
 // Todoist uses to create tasks with natural language processing. The text
 // parameter is the text of the task to create. The options parameter is
 // optional if you want to set additional options for the task.
-func (c *Client) QuickAddTask(text string, options *TaskOptions) (*Task, error) {
+func (c *Client) QuickAddTask(
+	ctx context.Context,
+	text string,
+	options *TaskOptions,
+) (*Task, error) {
 	body := struct {
 		Text string `json:"text"`
 	}{
 		Text: text,
 	}
-	res, err := c.request("POST", "/tasks/quick", body, nil)
+	res, err := c.request(ctx, "POST", "/tasks/quick", body, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -148,8 +157,8 @@ func (c *Client) QuickAddTask(text string, options *TaskOptions) (*Task, error) 
 
 // ReopenTask reopens a task that has been completed. The taskID parameter is
 // the ID of the task to reopen.
-func (c *Client) ReopenTask(taskID string) error {
-	res, err := c.request("POST", fmt.Sprintf("/tasks/%s/reopen", taskID), nil, nil)
+func (c *Client) ReopenTask(ctx context.Context, taskID string) error {
+	res, err := c.request(ctx, "POST", fmt.Sprintf("/tasks/%s/reopen", taskID), nil, nil)
 	if err != nil {
 		return err
 	}
@@ -163,8 +172,8 @@ func (c *Client) ReopenTask(taskID string) error {
 
 // CloseTask closes a task that has been completed. The taskID parameter is
 // the ID of the task to close.
-func (c *Client) CloseTask(taskID string) error {
-	res, err := c.request("POST", fmt.Sprintf("/tasks/%s/close", taskID), nil, nil)
+func (c *Client) CloseTask(ctx context.Context, taskID string) error {
+	res, err := c.request(ctx, "POST", fmt.Sprintf("/tasks/%s/close", taskID), nil, nil)
 	if err != nil {
 		return err
 	}
@@ -180,8 +189,8 @@ func (c *Client) CloseTask(taskID string) error {
 
 // GetTask returns a task related to the given taskID. The taskID parameter
 // is the ID of the task to get. The taskID parameter is required.
-func (c *Client) GetTask(taskID string) (*Task, error) {
-	res, err := c.request("GET", fmt.Sprintf("/tasks/%s", taskID), nil, nil)
+func (c *Client) GetTask(ctx context.Context, taskID string) (*Task, error) {
+	res, err := c.request(ctx, "GET", fmt.Sprintf("/tasks/%s", taskID), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -200,8 +209,12 @@ func (c *Client) GetTask(taskID string) (*Task, error) {
 }
 
 // UpdateTask updates a task with the given taskID with the given TaskOptions.
-func (c *Client) UpdateTask(taskID string, options *TaskOptions) (*Task, error) {
-	res, err := c.request("POST", fmt.Sprintf("/tasks/%s", taskID), options, nil)
+func (c *Client) UpdateTask(
+	ctx context.Context,
+	taskID string,
+	options *TaskOptions,
+) (*Task, error) {
+	res, err := c.request(ctx, "POST", fmt.Sprintf("/tasks/%s", taskID), options, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -221,8 +234,8 @@ func (c *Client) UpdateTask(taskID string, options *TaskOptions) (*Task, error) 
 
 // DeleteTask deletes a task with the given taskID. The taskID parameter is the
 // ID of the task to delete. The taskID parameter is required.
-func (c *Client) DeleteTask(taskID string) error {
-	res, err := c.request("DELETE", fmt.Sprintf("/tasks/%s", taskID), nil, nil)
+func (c *Client) DeleteTask(ctx context.Context, taskID string) error {
+	res, err := c.request(ctx, "DELETE", fmt.Sprintf("/tasks/%s", taskID), nil, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is needed to match with the idiomatic way of using context in Go, allowing for better cancellation and timeout handling in HTTP requests.

I am adding this now so that I do not run into API breaking changes in the future.