### PR TITLE
Add better error responses for API calls

### DIFF
--- a/pkg/todoist/comments.go
+++ b/pkg/todoist/comments.go
@@ -56,10 +56,6 @@ func (c *Client) GetComments(
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("get all comments unexpected status code: %d", res.StatusCode)
-	}
-
 	var pagiResp PaginationResponse[Comment]
 	err = json.NewDecoder(res.Body).Decode(&pagiResp)
 	if err != nil {
@@ -94,10 +90,6 @@ func (c *Client) CreateComment(
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("create comment unexpected status code: %d", res.StatusCode)
-	}
-
 	var comment Comment
 	err = json.NewDecoder(res.Body).Decode(&comment)
 	if err != nil {
@@ -117,10 +109,6 @@ func (c *Client) GetComment(ctx context.Context, commentID string) (*Comment, er
 		return nil, fmt.Errorf("failed to make get comment request: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("get comment unexpected status code: %d", res.StatusCode)
-	}
 
 	var comment Comment
 	err = json.NewDecoder(res.Body).Decode(&comment)
@@ -146,10 +134,6 @@ func (c *Client) UpdateComment(
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("update comment unexpected status code: %d", res.StatusCode)
-	}
-
 	var comment Comment
 	err = json.NewDecoder(res.Body).Decode(&comment)
 	if err != nil {
@@ -167,10 +151,6 @@ func (c *Client) DeleteComment(ctx context.Context, commentID string) error {
 		return fmt.Errorf("failed to make delete comment request: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("delete comment unexpected status code: %d", res.StatusCode)
-	}
 
 	return nil
 }

--- a/pkg/todoist/labels.go
+++ b/pkg/todoist/labels.go
@@ -52,10 +52,6 @@ func (c *Client) SharedLabels(
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("get shared labels unexpected status code: %d", res.StatusCode)
-	}
-
 	var pagiResp PaginationResponse[string]
 	err = json.NewDecoder(res.Body).Decode(&pagiResp)
 	if err != nil {
@@ -75,10 +71,6 @@ func (c *Client) GetLabels(
 		return nil, nil, fmt.Errorf("failed to get labels: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("get labels unexpected status code: %d", res.StatusCode)
-	}
 
 	var pagiResp PaginationResponse[Label]
 	err = json.NewDecoder(res.Body).Decode(&pagiResp)
@@ -112,10 +104,6 @@ func (c *Client) CreateLabel(
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("create label unexpected status code: %d", res.StatusCode)
-	}
-
 	var label Label
 	err = json.NewDecoder(res.Body).Decode(&label)
 	if err != nil {
@@ -138,10 +126,6 @@ func (c *Client) SharedLabelsRemove(ctx context.Context, name string) error {
 		return fmt.Errorf("failed to remove shared label: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("remove shared label unexpected status code: %d", res.StatusCode)
-	}
 
 	return nil
 }
@@ -167,10 +151,6 @@ func (c *Client) SharedLabelsRename(ctx context.Context, name string, newName st
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("rename shared label unexpected status code: %d", res.StatusCode)
-	}
-
 	return nil
 }
 
@@ -187,10 +167,6 @@ func (c *Client) DeleteLabel(ctx context.Context, id string) error {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("delete label unexpected status code: %d", res.StatusCode)
-	}
-
 	return nil
 }
 
@@ -205,10 +181,6 @@ func (c *Client) GetLabel(ctx context.Context, id string) (*Label, error) {
 		return nil, fmt.Errorf("failed to get label: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("get label unexpected status code: %d", res.StatusCode)
-	}
 
 	var label Label
 	err = json.NewDecoder(res.Body).Decode(&label)
@@ -238,10 +210,6 @@ func (c *Client) UpdateLabel(
 		return nil, fmt.Errorf("failed to update label: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("update label unexpected status code: %d", res.StatusCode)
-	}
 
 	var label Label
 	err = json.NewDecoder(res.Body).Decode(&label)

--- a/pkg/todoist/projects.go
+++ b/pkg/todoist/projects.go
@@ -72,13 +72,9 @@ func (c *Client) GetProjects(
 ) ([]Project, *string, error) {
 	res, err := c.request(ctx, "GET", "/projects/", nil, pagination)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get projects: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 
 	var pagiResp PaginationResponse[Project]
 	err = json.NewDecoder(res.Body).Decode(&pagiResp)
@@ -96,13 +92,9 @@ func (c *Client) GetArchived(
 ) ([]Project, *string, error) {
 	res, err := c.request(ctx, "GET", "/projects/archived", nil, pagination)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get archived projects: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 
 	var pagiResp PaginationResponse[Project]
 	err = json.NewDecoder(res.Body).Decode(&pagiResp)
@@ -131,13 +123,9 @@ func (c *Client) CreateProject(
 
 	res, err := c.request(ctx, "POST", "/projects", body, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create project: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 
 	var project Project
 	err = json.NewDecoder(res.Body).Decode(&project)
@@ -151,13 +139,9 @@ func (c *Client) CreateProject(
 func (c *Client) GetProject(ctx context.Context, projectId string) (*Project, error) {
 	res, err := c.request(ctx, "GET", fmt.Sprintf("/projects/%s", projectId), nil, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get project: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 
 	var project Project
 	err = json.NewDecoder(res.Body).Decode(&project)
@@ -176,13 +160,9 @@ func (c *Client) UpdateProject(
 ) (*Project, error) {
 	res, err := c.request(ctx, "POST", fmt.Sprintf("/projects/%s", projectId), options, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to update project: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 
 	var project Project
 	err = json.NewDecoder(res.Body).Decode(&project)
@@ -196,13 +176,9 @@ func (c *Client) UpdateProject(
 func (c *Client) ArchiveProject(ctx context.Context, projectId string) error {
 	res, err := c.request(ctx, "POST", fmt.Sprintf("/projects/%s/archive", projectId), nil, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to archive project: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 
 	return nil
 }
@@ -211,13 +187,9 @@ func (c *Client) ArchiveProject(ctx context.Context, projectId string) error {
 func (c *Client) UnarchiveProject(ctx context.Context, projectId string) error {
 	res, err := c.request(ctx, "POST", fmt.Sprintf("/projects/%s/unarchive", projectId), nil, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to unarchive project: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 
 	return nil
 }
@@ -226,13 +198,10 @@ func (c *Client) UnarchiveProject(ctx context.Context, projectId string) error {
 func (c *Client) DeleteProject(ctx context.Context, projectId string) error {
 	res, err := c.request(ctx, "DELETE", fmt.Sprintf("/projects/%s", projectId), nil, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete project: %w", err)
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 	return nil
 }
 
@@ -252,13 +221,9 @@ func (c *Client) GetProjectCollaborators(
 		pagination,
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get project collaborators: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 
 	var pagiResp PaginationResponse[Collaborator]
 	err = json.NewDecoder(res.Body).Decode(&pagiResp)

--- a/pkg/todoist/sections.go
+++ b/pkg/todoist/sections.go
@@ -64,10 +64,6 @@ func (c *Client) CreateSection(
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("create section unexpected status code: %d", res.StatusCode)
-	}
-
 	var section Section
 	err = json.NewDecoder(res.Body).Decode(&section)
 	if err != nil {
@@ -89,10 +85,6 @@ func (c *Client) GetSections(
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("get sections unexpected status code: %d", res.StatusCode)
-	}
-
 	var pagiResp PaginationResponse[Section]
 	err = json.NewDecoder(res.Body).Decode(&pagiResp)
 	if err != nil {
@@ -113,10 +105,6 @@ func (c *Client) GetSection(ctx context.Context, id string) (*Section, error) {
 		return nil, fmt.Errorf("failed to get section: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("get section unexpected status code: %d", res.StatusCode)
-	}
 
 	var section Section
 	err = json.NewDecoder(res.Body).Decode(&section)
@@ -146,10 +134,6 @@ func (c *Client) UpdateSection(ctx context.Context, id string, name string) (*Se
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("update section unexpected status code: %d", res.StatusCode)
-	}
-
 	var section Section
 	err = json.NewDecoder(res.Body).Decode(&section)
 	if err != nil {
@@ -170,10 +154,6 @@ func (c *Client) DeleteSection(ctx context.Context, id string) error {
 		return fmt.Errorf("failed to delete section: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("delete section unexpected status code: %d", res.StatusCode)
-	}
 
 	return nil
 }

--- a/pkg/todoist/tasks.go
+++ b/pkg/todoist/tasks.go
@@ -82,13 +82,9 @@ func (c *Client) CreateTask(
 
 	res, err := c.request(ctx, "POST", "/tasks", body, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create task: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 
 	var task Task
 	err = json.NewDecoder(res.Body).Decode(&task)
@@ -103,13 +99,9 @@ func (c *Client) CreateTask(
 func (c *Client) GetTasks(ctx context.Context, filters *TaskFilters) ([]Task, *string, error) {
 	res, err := c.request(ctx, "GET", "/tasks", nil, filters)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get tasks: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 
 	var pagiResp PaginationResponse[Task]
 	err = json.NewDecoder(res.Body).Decode(&pagiResp)
@@ -141,12 +133,10 @@ func (c *Client) QuickAddTask(
 	}
 	res, err := c.request(ctx, "POST", "/tasks/quick", body, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to quick add task: %w", err)
 	}
 	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
+
 	var task Task
 	err = json.NewDecoder(res.Body).Decode(&task)
 	if err != nil {
@@ -160,13 +150,10 @@ func (c *Client) QuickAddTask(
 func (c *Client) ReopenTask(ctx context.Context, taskID string) error {
 	res, err := c.request(ctx, "POST", fmt.Sprintf("/tasks/%s/reopen", taskID), nil, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to reopen task: %w", err)
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 	return nil
 }
 
@@ -175,13 +162,10 @@ func (c *Client) ReopenTask(ctx context.Context, taskID string) error {
 func (c *Client) CloseTask(ctx context.Context, taskID string) error {
 	res, err := c.request(ctx, "POST", fmt.Sprintf("/tasks/%s/close", taskID), nil, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to close task: %w", err)
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 	return nil
 }
 
@@ -192,13 +176,9 @@ func (c *Client) CloseTask(ctx context.Context, taskID string) error {
 func (c *Client) GetTask(ctx context.Context, taskID string) (*Task, error) {
 	res, err := c.request(ctx, "GET", fmt.Sprintf("/tasks/%s", taskID), nil, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get task: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 
 	var task Task
 	err = json.NewDecoder(res.Body).Decode(&task)
@@ -216,13 +196,9 @@ func (c *Client) UpdateTask(
 ) (*Task, error) {
 	res, err := c.request(ctx, "POST", fmt.Sprintf("/tasks/%s", taskID), options, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to update task: %w", err)
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 
 	var task Task
 	err = json.NewDecoder(res.Body).Decode(&task)
@@ -237,12 +213,9 @@ func (c *Client) UpdateTask(
 func (c *Client) DeleteTask(ctx context.Context, taskID string) error {
 	res, err := c.request(ctx, "DELETE", fmt.Sprintf("/tasks/%s", taskID), nil, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete task: %w", err)
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 	return nil
 }


### PR DESCRIPTION
Previously we were comparing if the response status code was not equal to what was expected and then we would return the status code back as an error but without any message from the Todoist server. This fixes that problem by also returning the response body in the error when we make our `APIError.Error()` gets called.

Todoist has also refactored their API so calls that previously return 204 now return 200. Making it easier to just check if we have an error.